### PR TITLE
Update db_host to point to RDS address not endpoint.

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -45,7 +45,7 @@ data "template_file" "install" {
 
     vars {
         rancher_version = "${var.rancher_version}"
-        db_host         = "${aws_rds_cluster.rancher_ha.endpoint}"
+        db_host         = "${aws_rds_cluster.rancher_ha.address}"
         db_name         = "${aws_rds_cluster.rancher_ha.database_name}"
         db_port         = "${aws_rds_cluster.rancher_ha.port}"
         db_user         = "${var.db_user}"


### PR DESCRIPTION
When using MySQL the address already contains the DB port which causes a fatal error when rancher attempts to connect to the DB.

Using the address allows us to specify the port individually.